### PR TITLE
Use manifest/name as canvas label, to ensure uniqueness

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ task :store_annotations do
       FileUtils::mkdir_p dir # make dir for canvas annotations
 
       make_anno_list(dir,name,manifest) # write canvas annotation list to file
-      store_anno_array(dir,name,sum_annotations) # write array of canvas annotations to file
+      store_anno_array(dir,name,manifest,sum_annotations) # write array of canvas annotations to file
 
       File.delete(canvas) # remove unstored data file
     end
@@ -35,12 +35,13 @@ def make_anno_list(dir,name,manifest)
   if !File.exist?(listpath) # make annotation list if necessary
     puts "creating " + listpath + ".\n"
     File.open(listpath, 'w') do |f|
-      f.write("---\nlayout: null\ncanvas: '" + name + "'\n---\n" + '{% assign anno_name = page.canvas | append: "-resources" %}{% assign annotations = site.pages | where: "label", anno_name | first %}{"@context": "http://iiif.io/api/presentation/2/context.json","@id": "{{ site.url }}{{ site.baseurl }}/annotations/' + manifest + '/' + name + '/list.json","@type": "sc:AnnotationList","resources": {{ annotations.content }} }')
+      # use manifest + '/' + name as canvas label, to ensure uniqueness across all manifests
+      f.write("---\nlayout: null\ncanvas: '" + manifest + '/' + name + "'\n---\n" + '{% assign anno_name = page.canvas | append: "-resources" %}{% assign annotations = site.pages | where: "label", anno_name | first %}{"@context": "http://iiif.io/api/presentation/2/context.json","@id": "{{ site.url }}{{ site.baseurl }}/annotations/' + manifest + '/' + name + '/list.json","@type": "sc:AnnotationList","resources": {{ annotations.content }} }')
     end
   end
 end
 
-def store_anno_array(dir,name,sum_annotations)
+def store_anno_array(dir,name,manifest,sum_annotations)
   annopath = dir +  "/" + name + ".json"
   if !File.exist?(annopath) # if no preexisting annotation file
     puts "creating " + annopath + ".\n"
@@ -49,14 +50,14 @@ def store_anno_array(dir,name,sum_annotations)
     old_annotations = JSON.parse(File.read(annopath).gsub(/\A---(.|\n)*?---/, ""))
     sum_annotations = sum_annotations.concat old_annotations # add annotation JSON to array
   end
-  File.open(annopath, 'w') { |f| f.write("---\nlayout: null\nlabel: " + name + "-resources\n---\n" + sum_annotations.to_json) }
+  File.open(annopath, 'w') { |f| f.write("---\nlayout: null\nlabel: " + manifest + '/' + name + "-resources\n---\n" + sum_annotations.to_json) }
 end
 
 def update_manifest_copy(manifest)
   stored_canvases = []
   Dir['annotations/' + manifest + "/*/"].each { | c | stored_canvases << File.basename(c, ".*") }
 
-  puts "adding annotation references for canvases " + stored_canvases.to_s + " to manifest copy."
+  puts "adding annotation references for canvases " + manifest + '/' + stored_canvases.to_s + " to manifest copy."
 
   manifest_json = JSON.parse(File.read("iiif/" + manifest + "/clean-manifest.json").gsub(/\A---(.|\n)*?---/, "").to_s)
   canvases = manifest_json["sequences"][0]["canvases"].select {|c| stored_canvases.include? c["@id"].split('/')[-1] }


### PR DESCRIPTION
Fixes #3 

I've just used the existing ```manifest``` variable to pass the manifest name to the two methods that write Jekyll-style Markdown headers for annotations lists. They compose the canvas label in the form ```manifest + '/' + name```. I haven't changed the annotations in the examples to use this form; they'll only have this problem if more examples are added that use the same canvas names as one of the existing ones.

I've tested it with bnf640. The copperfield example isn't working for me (every annotation I create gets assigned to 10.json); I haven't investigated why.